### PR TITLE
Fix typo in Site.css that caused a layout issue

### DIFF
--- a/Templates/Site.css
+++ b/Templates/Site.css
@@ -153,7 +153,7 @@ section h2 {
   flex-grow:   0;
   flex-shrink: 0;
 }
-.large-3 {
+.large-6 {
   max-width:   50%;
   flex-basis:  50%;
   flex-grow:   0;


### PR DESCRIPTION
This used to cause excessive horizontal scrolling in below component, as `.large-3` (50%) and `.large-9` (75%) together had more than 125% width.

https://github.com/DoccZz/docc2html/blob/5588eb6377339e8a982a74d5dfb34f2ed315f5a0/Templates/Sections.mustache#L7-L13