### PR TITLE
Render strikethrough inline content

### DIFF
--- a/Sources/DocCHTMLExporter/HTML/InlineContentHTML.swift
+++ b/Sources/DocCHTMLExporter/HTML/InlineContentHTML.swift
@@ -25,6 +25,8 @@ extension DocCArchive.InlineContent {
         
       case .emphasis(let value):
         return "<em>" + value.generateHTML(in: ctx) + "</em>"
+      case .strikethrough(let value):
+        return "<s>" + value.generateHTML(in: ctx) + "</s>"
       case .strong(let value):
         return "<strong>" + value.generateHTML(in: ctx) + "</strong>"
       case .reference(let identifier, let isActive,


### PR DESCRIPTION
Changes to adopt the strikethrough `InlineContent` changes here: https://github.com/DoccZz/DocCArchive/pull/10