### PR TITLE
Consume changes to `ImageReference` making the `alt` property optional

### DIFF
--- a/Sources/DocCHTMLExporter/HTML/ReferenceHTML.swift
+++ b/Sources/DocCHTMLExporter/HTML/ReferenceHTML.swift
@@ -90,8 +90,8 @@ extension DocCArchive.Reference {
         return ref.abstract.generateHTML(in: ctx)
         
       case .image(let ref):
-        return ref.alt.htmlEscaped
-      
+        return ref.alt?.htmlEscaped ?? ""
+
       case .link(let ref):
         return ref.title.htmlEscaped
 
@@ -150,7 +150,7 @@ extension DocCArchive.ImageReference {
   func generateHTML(in ctx: DZRenderingContext) -> String {
     guard let variant = bestVariant(for: ctx.traits) else {
       assertionFailure("Got no image variant?")
-      return "<!-- invalid image ref -->\(alt.htmlEscaped)"
+      return "<!-- invalid image ref -->\(alt?.htmlEscaped ?? "")"
     }
     
     let media : String = {
@@ -173,7 +173,7 @@ extension DocCArchive.ImageReference {
     var ms = "<picture><source\(media) srcset='\(srcset)'>"
 
     ms += "<img"
-    if !alt.isEmpty { ms += " alt='\(alt.htmlEscaped)'" }
+    if let alt = alt, !alt.isEmpty { ms += " alt='\(alt.htmlEscaped)'" }
     ms += " srcset='\(srcset)'"
     ms += " src='\(url.htmlEscaped)'"
     if let size = variant.size { ms += " width='\(size.width)' height='auto'" }


### PR DESCRIPTION
Consume changes to the alt text being optional.