### PR TITLE
Capitalizes references to the dependency Mustache and bumps version

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
   
   dependencies: [
     .package(url  : "https://github.com/AlwaysRightInstitute/mustache.git",
-             from : "1.0.1"),
+             from : "1.0.2"),
     .package(url  : "https://github.com/DoccZz/DocCArchive.git",
              from : "0.4.1"),
     .package(url  : "https://github.com/apple/swift-log.git",
@@ -23,7 +23,7 @@ let package = Package(
   
   targets: [
     .target(name         : "DocCHTMLExporter",
-            dependencies : [ "DocCArchive", "mustache", "Logging" ]),
+            dependencies : [ "DocCArchive", "Mustache", "Logging" ]),
     .target(name         : "DocCStaticExporter",
             dependencies : [ "DocCArchive", "DocCHTMLExporter", "Logging" ]),
     .target(name         : "docc2html",

--- a/Sources/DocCHTMLExporter/DZRenderingContext.swift
+++ b/Sources/DocCHTMLExporter/DZRenderingContext.swift
@@ -9,7 +9,7 @@
 import struct Foundation.URL
 import DocCArchive
 import Logging
-import mustache
+import Mustache
 
 /**
  * The object is used for rendering a single document. Not intended to be

--- a/Sources/DocCHTMLExporter/Templates/CodeListing.swift
+++ b/Sources/DocCHTMLExporter/Templates/CodeListing.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2021 ZeeZide GmbH. All rights reserved.
 //
 
-import mustache
+import Mustache
 
 let CodeListingTemplate = Mustache(
   """

--- a/Sources/DocCHTMLExporter/Templates/DeclarationSection.swift
+++ b/Sources/DocCHTMLExporter/Templates/DeclarationSection.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2021 ZeeZide GmbH. All rights reserved.
 //
 
-import mustache
+import Mustache
 
 // FIXME: This is slightly wrong, we need to loop over the declarations within.
 let DeclarationSectionTemplate = Mustache(

--- a/Sources/DocCHTMLExporter/Templates/DocumentContent.swift
+++ b/Sources/DocCHTMLExporter/Templates/DocumentContent.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2021 ZeeZide GmbH. All rights reserved.
 //
 
-import mustache
+import Mustache
 
 let DocumentContentTemplate = Mustache(
   """

--- a/Sources/DocCHTMLExporter/Templates/Hero.swift
+++ b/Sources/DocCHTMLExporter/Templates/Hero.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2021 ZeeZide GmbH. All rights reserved.
 //
 
-import mustache
+import Mustache
 
 let HeroTemplate = Mustache(
   """

--- a/Sources/DocCHTMLExporter/Templates/Navigation.swift
+++ b/Sources/DocCHTMLExporter/Templates/Navigation.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2021 ZeeZide GmbH. All rights reserved.
 //
 
-import mustache
+import Mustache
 
 // TBD:
 // nav: interfacelanguage, swiftpath, aria-label, svg for triangle

--- a/Sources/DocCHTMLExporter/Templates/Page.swift
+++ b/Sources/DocCHTMLExporter/Templates/Page.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2021 ZeeZide GmbH. All rights reserved.
 //
 
-import mustache
+import Mustache
 
 #if false // attempt to reuse the stylesheets, but doesn't really fly
   fileprivate let stylesheets = [

--- a/Sources/DocCHTMLExporter/Templates/ParametersSection.swift
+++ b/Sources/DocCHTMLExporter/Templates/ParametersSection.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2021 ZeeZide GmbH. All rights reserved.
 //
 
-import mustache
+import Mustache
 
 let ParametersSectionTemplate = Mustache(
   """

--- a/Sources/DocCHTMLExporter/Templates/PrimaryContent.swift
+++ b/Sources/DocCHTMLExporter/Templates/PrimaryContent.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2021 ZeeZide GmbH. All rights reserved.
 //
 
-import mustache
+import Mustache
 
 let PrimaryContentGridTemplate = Mustache(
   """

--- a/Sources/DocCHTMLExporter/Templates/Sections.swift
+++ b/Sources/DocCHTMLExporter/Templates/Sections.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2021 ZeeZide GmbH. All rights reserved.
 //
 
-import mustache
+import Mustache
 
 let ContentTableSectionTemplate = Mustache(
   """

--- a/Sources/DocCHTMLExporter/Templates/StepContent.swift
+++ b/Sources/DocCHTMLExporter/Templates/StepContent.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2021 ZeeZide GmbH. All rights reserved.
 //
 
-import mustache
+import Mustache
 
 // TODO: do something w/ the media stuff
 // the app itself does a lot of extra div's for the modal overlay presentation

--- a/Sources/DocCHTMLExporter/Templates/Task.swift
+++ b/Sources/DocCHTMLExporter/Templates/Task.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2021 ZeeZide GmbH. All rights reserved.
 //
 
-import mustache
+import Mustache
 
 // Parameters: anchor, introHTML, stepsHTML
 // intro is the display: flex

--- a/Sources/DocCHTMLExporter/Templates/TopicTitle.swift
+++ b/Sources/DocCHTMLExporter/Templates/TopicTitle.swift
@@ -7,7 +7,7 @@
 //
 //
 
-import mustache
+import Mustache
 
 let TopicTitleTemplate = Mustache(
   """

--- a/Sources/DocCHTMLExporter/Templates/Volume.swift
+++ b/Sources/DocCHTMLExporter/Templates/Volume.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2021 ZeeZide GmbH. All rights reserved.
 //
 
-import mustache
+import Mustache
 
 let VolumeTemplate = Mustache(
   """

--- a/Sources/docc2html/LoadTemplates.swift
+++ b/Sources/docc2html/LoadTemplates.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2021 ZeeZide GmbH. All rights reserved.
 //
 
-import mustache
+import Mustache
 import Foundation
 import DocCHTMLExporter // @docczz/docc2html
 


### PR DESCRIPTION
Fixes error: 'docc2html': product 'mustache' required by package 'docc2html' target 'DocCHTMLExporter' not found. Did you mean 'Mustache'? Issue: https://github.com/DoccZz/docc2html/issues/28